### PR TITLE
feat(config) use the host parameter and not a custom variable

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -12,8 +12,22 @@
       <!-- supportlevel value="certified"/ -->
     </information>
     <configuration>
-      <property key="port" label="Elasticsearch REST port" type="long" description="The port where the Elasticsearch Cluster REST interface is available" default="9200" multiline="false" />    
-      <property key="protocol" label="Elasticsearch REST protocol" type="string" description="The protocol where the Elasticsearch Cluster REST interface is available" default="http" multiline="false" />
+      <property key="useFullUrlConfiguration" label="useFullUrlConfiguration" type="boolean" description="when true url is used to connect to Elasticsearch when false the Dynatrace native server list is used" default="true" />
+      <property key="url" label="Elasticsearch REST URL" type="string" description="The URL where the Elasticsearch Cluster REST interface is available" default="http://localhost:9200" multiline="false" >
+        <visibility>
+          <rule key="useFullUrlConfiguration" value="false" />
+        </visibility>
+      </property>  
+      <property key="port" label="Elasticsearch REST port" type="long" description="The port where the Elasticsearch Cluster REST interface is available" default="9200" multiline="false" >
+        <visibility>
+          <rule key="useFullUrlConfiguration" value="true" />
+        </visibility>
+      </property>     
+      <property key="protocol" label="Elasticsearch REST protocol" type="string" description="The protocol where the Elasticsearch Cluster REST interface is available" default="http" multiline="false" >
+        <visibility>
+          <rule key="useFullUrlConfiguration" value="true" />
+        </visibility>
+      </property>  
       <property key="user" label="User" type="string" description="User name to use to connect via Basic Authentication, leave empty for unauthenticated access" default="" multiline="false" />
       <property key="password" label="Password" type="password" description="Password if authentication is required, leave empty for unauthenticated access" default="" />
       <property key="timeout" label="Timeout" type="long" description="Timeout in milliseconds used when accessing the REST interface via HTTP" default="60000" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -12,10 +12,11 @@
       <!-- supportlevel value="certified"/ -->
     </information>
     <configuration>
-		<property key="url" label="Elasticsearch REST URL" type="string" description="The URL where the Elasticsearch Cluster REST interface is available" default="http://localhost:9200" multiline="false" />
-		<property key="user" label="User" type="string" description="User name to use to connect via Basic Authentication, leave empty for unauthenticated access" default="" multiline="false" />
-		<property key="password" label="Password" type="password" description="Password if authentication is required, leave empty for unauthenticated access" default="" />
-		<property key="timeout" label="Timeout" type="long" description="Timeout in milliseconds used when accessing the REST interface via HTTP" default="60000" />
+      <property key="port" label="Elasticsearch REST port" type="long" description="The port where the Elasticsearch Cluster REST interface is available" default="9200" multiline="false" />    
+      <property key="protocol" label="Elasticsearch REST protocol" type="string" description="The protocol where the Elasticsearch Cluster REST interface is available" default="http" multiline="false" />
+      <property key="user" label="User" type="string" description="User name to use to connect via Basic Authentication, leave empty for unauthenticated access" default="" multiline="false" />
+      <property key="password" label="Password" type="password" description="Password if authentication is required, leave empty for unauthenticated access" default="" />
+      <property key="timeout" label="Timeout" type="long" description="Timeout in milliseconds used when accessing the REST interface via HTTP" default="60000" />
     </configuration>
   </extension>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,17 +15,17 @@
       <property key="useFullUrlConfiguration" label="useFullUrlConfiguration" type="boolean" description="when true url is used to connect to Elasticsearch when false the Dynatrace native server list is used" default="true" />
       <property key="url" label="Elasticsearch REST URL" type="string" description="The URL where the Elasticsearch Cluster REST interface is available" default="http://localhost:9200" multiline="false" >
         <visibility>
-          <rule key="useFullUrlConfiguration" value="false" />
+          <rule key="useFullUrlConfiguration" value="true" />
         </visibility>
       </property>  
       <property key="port" label="Elasticsearch REST port" type="long" description="The port where the Elasticsearch Cluster REST interface is available" default="9200" multiline="false" >
         <visibility>
-          <rule key="useFullUrlConfiguration" value="true" />
+          <rule key="useFullUrlConfiguration" value="false" />
         </visibility>
       </property>     
       <property key="protocol" label="Elasticsearch REST protocol" type="string" description="The protocol where the Elasticsearch Cluster REST interface is available" default="http" multiline="false" >
         <visibility>
-          <rule key="useFullUrlConfiguration" value="true" />
+          <rule key="useFullUrlConfiguration" value="false" />
         </visibility>
       </property>  
       <property key="user" label="User" type="string" description="User name to use to connect via Basic Authentication, leave empty for unauthenticated access" default="" multiline="false" />

--- a/src/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitor.java
+++ b/src/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitor.java
@@ -10,6 +10,7 @@ import com.dynatrace.diagnostics.pdk.MonitorEnvironment;
 import com.dynatrace.diagnostics.pdk.MonitorMeasure;
 import com.dynatrace.diagnostics.pdk.Status;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.dynatrace.diagnostics.pdk.PluginEnvironment.Host;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.IOUtils;
@@ -188,13 +189,15 @@ public class ElasticsearchMonitor implements Monitor {
 	@Override
 	public Status setup(MonitorEnvironment env) throws Exception {
 
-		port = env.getConfigLong(ENV_CONFIG_PORT).intValue();
+		Long tempPort = env.getConfigLong(ENV_CONFIG_PORT);
+
 		protocol =  env.getConfigString(ENV_CONFIG_PROTOCOL);
-		url = protocol+"://"+env.getHost().getAddress()+":"+port;
-		if (url == null || url.isEmpty())
+		Host host = env.getHost();
+		if ( protocol ==null || tempPort==null || host == null || host.getAddress() == null || host.getAddress().isEmpty())
 			throw new IllegalArgumentException(
 					"Parameter <url> must not be empty");
-
+		port = tempPort.intValue();
+		url = protocol+"://"+host.getAddress()+":"+port;
 		// normalize URL
 		url = StringUtils.removeEnd(url, "/");
 

--- a/src/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitor.java
+++ b/src/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitor.java
@@ -52,6 +52,8 @@ public class ElasticsearchMonitor implements Monitor {
 	private static final Logger log = Logger.getLogger(ElasticsearchMonitor.class.getName());
 
 	/************************************** Config properties **************************/
+	protected static final String ENV_CONFIG_USE_FULL_URL_CONFIGURATION = "useFullUrlConfiguration";
+	protected static final String ENV_CONFIG_URL = "url";
 	protected static final String ENV_CONFIG_PORT = "port";
 	protected static final String ENV_CONFIG_PROTOCOL = "protocol";
 	protected static final String ENV_CONFIG_USER = "user";
@@ -166,6 +168,7 @@ public class ElasticsearchMonitor implements Monitor {
 
 	/************************************** Variables for Configuration items **************************/
 
+	private Boolean useFullUrlConfiguration = false;
 	private String url;
 	private int port;
 	private String protocol;
@@ -192,12 +195,21 @@ public class ElasticsearchMonitor implements Monitor {
 		Long tempPort = env.getConfigLong(ENV_CONFIG_PORT);
 
 		protocol =  env.getConfigString(ENV_CONFIG_PROTOCOL);
-		Host host = env.getHost();
-		if ( protocol ==null || tempPort==null || host == null || host.getAddress() == null || host.getAddress().isEmpty())
-			throw new IllegalArgumentException(
-					"Parameter <url> must not be empty");
-		port = tempPort.intValue();
-		url = protocol+"://"+host.getAddress()+":"+port;
+
+		useFullUrlConfiguration =env.getConfigBoolean(ENV_CONFIG_USE_FULL_URL_CONFIGURATION);
+		if(useFullUrlConfiguration) {
+			url = env.getConfigString(ENV_CONFIG_URL);
+			if (url == null || url.isEmpty()) {
+				throw new IllegalArgumentException("Parameter <url> must not be empty");
+			}
+		}
+		else {
+			Host host = env.getHost();
+			if (protocol == null || tempPort == null || host == null || host.getAddress() == null || host.getAddress().isEmpty())
+				throw new IllegalArgumentException("Parameters <protocol>, <port> and the dynatrace native host list  must not be empty");
+			port = tempPort.intValue();
+			url = protocol + "://" + host.getAddress() + ":" + port;
+		}
 		// normalize URL
 		url = StringUtils.removeEnd(url, "/");
 

--- a/src/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitor.java
+++ b/src/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitor.java
@@ -51,7 +51,8 @@ public class ElasticsearchMonitor implements Monitor {
 	private static final Logger log = Logger.getLogger(ElasticsearchMonitor.class.getName());
 
 	/************************************** Config properties **************************/
-	protected static final String ENV_CONFIG_URL = "url";
+	protected static final String ENV_CONFIG_PORT = "port";
+	protected static final String ENV_CONFIG_PROTOCOL = "protocol";
 	protected static final String ENV_CONFIG_USER = "user";
 	protected static final String ENV_CONFIG_PASSWORD = "password";
 	protected static final String ENV_CONFIG_TIMEOUT = "timeout";
@@ -165,6 +166,8 @@ public class ElasticsearchMonitor implements Monitor {
 	/************************************** Variables for Configuration items **************************/
 
 	private String url;
+	private int port;
+	private String protocol;
 	private String user;
 	private String password;
 	private long timeout;
@@ -184,7 +187,10 @@ public class ElasticsearchMonitor implements Monitor {
 	 */
 	@Override
 	public Status setup(MonitorEnvironment env) throws Exception {
-		url = env.getConfigString(ENV_CONFIG_URL);
+
+		port = env.getConfigLong(ENV_CONFIG_PORT).intValue();
+		protocol =  env.getConfigString(ENV_CONFIG_PROTOCOL);
+		url = protocol+"://"+env.getHost().getAddress()+":"+port;
 		if (url == null || url.isEmpty())
 			throw new IllegalArgumentException(
 					"Parameter <url> must not be empty");

--- a/testsrc/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitorMockRESTTest.java
+++ b/testsrc/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitorMockRESTTest.java
@@ -14,6 +14,7 @@ import com.dynatrace.diagnostics.sdk.HostImpl;
 import com.dynatrace.diagnostics.sdk.MonitorEnvironment30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasure30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasureKey;
+import com.dynatrace.diagnostics.sdk.types.BooleanType;
 import com.dynatrace.diagnostics.sdk.types.LongType;
 import com.dynatrace.diagnostics.sdk.types.StringType;
 import org.dstadler.commons.http.NanoHTTPD;
@@ -128,6 +129,11 @@ public class ElasticsearchMonitorMockRESTTest {
 			propertyPort.setValue(port.toString());
 			pluginConfig.addPluginPropertyConfig(propertyPort);
 
+			PluginPropertyInstanceConfig useFullConfiguration = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION);
+			useFullConfiguration.setSourceTypeId(BooleanType.TYPE_ID);
+			useFullConfiguration.setValue(Boolean.FALSE.toString());
+			pluginConfig.addPluginPropertyConfig(useFullConfiguration);
+
 		}
 
 		PluginTypeConfig pluginTypeConfig = new PluginTypeConfig();
@@ -147,6 +153,11 @@ public class ElasticsearchMonitorMockRESTTest {
 			propertyPort.setType(LongType.TYPE_ID);
 			propertyPort.setValue(port.toString());
 			pluginTypeConfig.addPluginPropertyConfig(propertyPort);
+
+			PluginPropertyTypeConfig useFullConfiguration = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION,new BooleanType(Boolean.FALSE,Boolean.FALSE));
+			useFullConfiguration.setSourceTypeId(BooleanType.TYPE_ID);
+			useFullConfiguration.setValue(Boolean.FALSE.toString());
+			pluginTypeConfig.addPluginPropertyConfig(useFullConfiguration);
 		}
 
 		// register all measure groups to have them available during the test

--- a/testsrc/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitorMockRESTTest.java
+++ b/testsrc/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitorMockRESTTest.java
@@ -10,9 +10,11 @@ import com.dynatrace.diagnostics.global.PluginPropertyInstanceConfig;
 import com.dynatrace.diagnostics.global.PluginPropertyTypeConfig;
 import com.dynatrace.diagnostics.global.PluginTypeConfig;
 import com.dynatrace.diagnostics.pdk.MonitorMeasure;
+import com.dynatrace.diagnostics.sdk.HostImpl;
 import com.dynatrace.diagnostics.sdk.MonitorEnvironment30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasure30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasureKey;
+import com.dynatrace.diagnostics.sdk.types.LongType;
 import com.dynatrace.diagnostics.sdk.types.StringType;
 import org.dstadler.commons.http.NanoHTTPD;
 import org.dstadler.commons.testing.MemoryLeakVerifier;
@@ -69,7 +71,8 @@ public class ElasticsearchMonitorMockRESTTest {
 
     private void runWithResponse(ElasticsearchMonitor monitor, String response, double expectedValue, double uncertainty) throws Exception {
         try (MockRESTServer server = new MockRESTServer(NanoHTTPD.HTTP_OK, "application/json", response)) {
-            MonitorEnvironment30Impl env = prepareMonitorEnvironment("http://localhost:" + server.getPort());
+
+            MonitorEnvironment30Impl env = prepareMonitorEnvironment("http","localhost" , Long.valueOf(server.getPort()));
 
             // now start executing the plugin
             monitor.setup(env);
@@ -109,31 +112,45 @@ public class ElasticsearchMonitorMockRESTTest {
 		assertEquals("Expected to find the measure exactly once, but had: " + found, 1, found);
 	}
 
-	private MonitorEnvironment30Impl prepareMonitorEnvironment(String URL) {
+	private MonitorEnvironment30Impl prepareMonitorEnvironment(String protocol, String URL,Long port) {
 		PluginInstanceConfig pluginConfig = new PluginInstanceConfig();
+
 		pluginConfig.setKey("elasticsearch");
 
 		{
-			PluginPropertyInstanceConfig environment = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_URL);
-			environment.setSourceTypeId(StringType.TYPE_ID);
-			environment.setValue(URL);
-			pluginConfig.addPluginPropertyConfig(environment);
+			PluginPropertyInstanceConfig propertyProtocol = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL);
+			propertyProtocol.setSourceTypeId(StringType.TYPE_ID);
+			propertyProtocol.setValue(protocol);
+			pluginConfig.addPluginPropertyConfig(propertyProtocol);
+
+			PluginPropertyInstanceConfig propertyPort = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_PORT);
+			propertyPort.setSourceTypeId(LongType.TYPE_ID);
+			propertyPort.setValue(port.toString());
+			pluginConfig.addPluginPropertyConfig(propertyPort);
+
 		}
 
 		PluginTypeConfig pluginTypeConfig = new PluginTypeConfig();
 		pluginTypeConfig.setKey("elasticsearch");
 
 		{
-			PluginPropertyTypeConfig environmentType = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_URL, new StringType("some",
+			PluginPropertyTypeConfig propertyProtocol = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL, new StringType("some",
 					""));
-			environmentType.setSourceTypeId(StringType.TYPE_ID);
-			environmentType.setType(StringType.TYPE_ID);
-			environmentType.setValue(URL);
-			pluginTypeConfig.addPluginPropertyConfig(environmentType);
+			propertyProtocol.setSourceTypeId(StringType.TYPE_ID);
+			propertyProtocol.setType(StringType.TYPE_ID);
+			propertyProtocol.setValue(protocol);
+			pluginTypeConfig.addPluginPropertyConfig(propertyProtocol);
+
+			PluginPropertyTypeConfig propertyPort = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_PORT, new LongType(1234L,
+					9200L));
+			propertyPort.setSourceTypeId(LongType.TYPE_ID);
+			propertyPort.setType(LongType.TYPE_ID);
+			propertyPort.setValue(port.toString());
+			pluginTypeConfig.addPluginPropertyConfig(propertyPort);
 		}
 
 		// register all measure groups to have them available during the test
-		MonitorEnvironment30Impl env = new MonitorEnvironment30Impl(null, pluginConfig, pluginTypeConfig, false, null);
+		MonitorEnvironment30Impl env = new MonitorEnvironment30Impl(new HostImpl(URL), pluginConfig, pluginTypeConfig, false, null);
 		{
 			for(String measure : ElasticsearchMonitor.ALL_MEASURES) {
 				createMeasure(env, ElasticsearchMonitor.METRIC_GROUP_ELASTICSEARCH, measure);

--- a/testsrc/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitorTest.java
+++ b/testsrc/com/dynatrace/diagnostics/plugins/elasticsearch/ElasticsearchMonitorTest.java
@@ -8,6 +8,7 @@ package com.dynatrace.diagnostics.plugins.elasticsearch;
 import com.dynatrace.diagnostics.pdk.MonitorEnvironment;
 import com.dynatrace.diagnostics.pdk.MonitorMeasure;
 import com.dynatrace.diagnostics.pdk.PluginEnvironment;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.dstadler.commons.http.NanoHTTPD;
 import org.dstadler.commons.testing.MockRESTServer;
 import org.dstadler.commons.testing.TestHelpers;
@@ -40,8 +41,11 @@ public class ElasticsearchMonitorTest {
 
 		MonitorEnvironment env = createStrictMock(MonitorEnvironment.class);
 
+
 		expect(env.getConfigLong(ElasticsearchMonitor.ENV_CONFIG_PORT)).andReturn(0L);
 		expect(env.getConfigString(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL)).andReturn("");
+		expect(env.getConfigBoolean(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION)).andReturn(Boolean.FALSE);
+
 		expect(env.getHost()).andReturn(new HostImpl(""));
 
 		replay(env);
@@ -65,6 +69,7 @@ public class ElasticsearchMonitorTest {
 
 		expect(env.getConfigLong(ElasticsearchMonitor.ENV_CONFIG_PORT)).andReturn(0L);
 		expect(env.getConfigString(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL)).andReturn("");
+		expect(env.getConfigBoolean(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION)).andReturn(Boolean.FALSE);
 		expect(env.getHost()).andReturn(new HostImpl(""));
 
 		replay(env);
@@ -101,6 +106,8 @@ public class ElasticsearchMonitorTest {
 
 		MonitorEnvironment env = createNiceMock(MonitorEnvironment.class);
 
+		//default value is false
+		expect(env.getConfigBoolean(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION)).andReturn(Boolean.FALSE);
 		replay(env);
 		try {
 			monitor.setup(env);
@@ -112,8 +119,10 @@ public class ElasticsearchMonitorTest {
 
 		reset(env);
 
+
 		expect(env.getConfigString(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL)).andReturn("http");
 		expect(env.getConfigLong(ElasticsearchMonitor.ENV_CONFIG_PORT)).andReturn(9200L);
+		expect(env.getConfigBoolean(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION)).andReturn(Boolean.FALSE);
 		expect(env.getHost()).andReturn(new HostImpl("localhost"));
 
 		replay(env);
@@ -207,6 +216,7 @@ public class ElasticsearchMonitorTest {
     private void expectSetup(MonitorEnvironment env, String protocol,String url, Long port) {
 		expect(env.getConfigLong(ElasticsearchMonitor.ENV_CONFIG_PORT)).andReturn(port);
 		expect(env.getConfigString(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL)).andReturn(protocol);
+		expect(env.getConfigBoolean(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION)).andReturn(Boolean.FALSE);
 		expect(env.getHost()).andReturn(new HostImpl(url));
 		expect(env.getConfigString(ElasticsearchMonitor.ENV_CONFIG_USER)).andReturn("invalid");
 		expect(env.getConfigPassword(ElasticsearchMonitor.ENV_CONFIG_PASSWORD)).andReturn("invalid");
@@ -258,8 +268,6 @@ public class ElasticsearchMonitorTest {
     private MonitorEnvironment prepareMonitoringEnvironment(ElasticsearchMonitor monitor, MockRESTServer server) throws Exception {
         MonitorEnvironment env = createStrictMock(MonitorEnvironment.class);
         expectSetup(env, "http","localhost",  Long.valueOf(server.getPort()));
-
-
 
         replay(env);
 

--- a/testsrcBelowES2/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTestES174.java
+++ b/testsrcBelowES2/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTestES174.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import com.dynatrace.diagnostics.sdk.HostImpl;
+import com.dynatrace.diagnostics.sdk.types.LongType;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -53,7 +55,9 @@ public class ExecuteElasticsearchMonitorTestES174 extends ElasticsearchIntegrati
     private static final String HTTP_TRANSPORT_PORT = "9305";
 
     // which URL do we use in test
-	private static final String URL = "http://localhost:9205";
+	private static final Long PORT = 9205L;
+	private static final String PROTOCOL = "http";
+	private static final String URL = "localhost";
 
 	@Override
 	protected Settings nodeSettings(int nodeOrdinal) {
@@ -220,29 +224,44 @@ public class ExecuteElasticsearchMonitorTestES174 extends ElasticsearchIntegrati
 
 	private MonitorEnvironment30Impl prepareMonitorEnvironment() {
 		PluginInstanceConfig pluginConfig = new PluginInstanceConfig();
+
 		pluginConfig.setKey("elasticsearch");
 
 		{
-			PluginPropertyInstanceConfig environment = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_URL);
-			environment.setSourceTypeId(StringType.TYPE_ID);
-			environment.setValue(URL);
-			pluginConfig.addPluginPropertyConfig(environment);
+			PluginPropertyInstanceConfig propertyProtocol = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL);
+			propertyProtocol.setSourceTypeId(StringType.TYPE_ID);
+			propertyProtocol.setValue(PROTOCOL);
+			pluginConfig.addPluginPropertyConfig(propertyProtocol);
+
+			PluginPropertyInstanceConfig propertyPort = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_PORT);
+			propertyPort.setSourceTypeId(LongType.TYPE_ID);
+			propertyPort.setValue(PORT.toString());
+			pluginConfig.addPluginPropertyConfig(propertyPort);
+
 		}
 
 		PluginTypeConfig pluginTypeConfig = new PluginTypeConfig();
 		pluginTypeConfig.setKey("elasticsearch");
 
 		{
-			PluginPropertyTypeConfig environmentType = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_URL, new StringType("some",
+			PluginPropertyTypeConfig propertyProtocol = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL, new StringType("some",
 					""));
-			environmentType.setSourceTypeId(StringType.TYPE_ID);
-			environmentType.setType(StringType.TYPE_ID);
-			environmentType.setValue(URL);
-			pluginTypeConfig.addPluginPropertyConfig(environmentType);
+			propertyProtocol.setSourceTypeId(StringType.TYPE_ID);
+			propertyProtocol.setType(StringType.TYPE_ID);
+			propertyProtocol.setValue(PROTOCOL);
+			pluginTypeConfig.addPluginPropertyConfig(propertyProtocol);
+
+			PluginPropertyTypeConfig propertyPort = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_PORT, new LongType(0L,
+					9200L));
+			propertyPort.setSourceTypeId(LongType.TYPE_ID);
+			propertyPort.setType(LongType.TYPE_ID);
+			propertyPort.setValue(PORT.toString());
+			pluginTypeConfig.addPluginPropertyConfig(propertyPort);
 		}
 
 		// register all measure groups to have them available during the test
-		MonitorEnvironment30Impl env = new MonitorEnvironment30Impl(null, pluginConfig, pluginTypeConfig, false, null);
+
+		MonitorEnvironment30Impl env = new MonitorEnvironment30Impl(new HostImpl(URL), pluginConfig, pluginTypeConfig, false, null);
 		{
 			for(String measure : ElasticsearchMonitor.ALL_MEASURES) {
 				createMeasure(env, ElasticsearchMonitor.METRIC_GROUP_ELASTICSEARCH, measure);

--- a/testsrcBelowES2/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTestES174.java
+++ b/testsrcBelowES2/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTestES174.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import com.dynatrace.diagnostics.sdk.HostImpl;
+import com.dynatrace.diagnostics.sdk.types.BooleanType;
 import com.dynatrace.diagnostics.sdk.types.LongType;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -238,6 +239,11 @@ public class ExecuteElasticsearchMonitorTestES174 extends ElasticsearchIntegrati
 			propertyPort.setValue(PORT.toString());
 			pluginConfig.addPluginPropertyConfig(propertyPort);
 
+			PluginPropertyInstanceConfig useFullConfiguration = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION);
+			useFullConfiguration.setSourceTypeId(BooleanType.TYPE_ID);
+			useFullConfiguration.setValue(Boolean.FALSE.toString());
+			pluginConfig.addPluginPropertyConfig(useFullConfiguration);
+
 		}
 
 		PluginTypeConfig pluginTypeConfig = new PluginTypeConfig();
@@ -257,6 +263,11 @@ public class ExecuteElasticsearchMonitorTestES174 extends ElasticsearchIntegrati
 			propertyPort.setType(LongType.TYPE_ID);
 			propertyPort.setValue(PORT.toString());
 			pluginTypeConfig.addPluginPropertyConfig(propertyPort);
+
+			PluginPropertyTypeConfig useFullConfiguration = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION,new BooleanType(Boolean.FALSE,Boolean.FALSE));
+			useFullConfiguration.setSourceTypeId(BooleanType.TYPE_ID);
+			useFullConfiguration.setValue(Boolean.FALSE.toString());
+			pluginTypeConfig.addPluginPropertyConfig(useFullConfiguration);
 		}
 
 		// register all measure groups to have them available during the test

--- a/testsrcES2/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTest.java
+++ b/testsrcES2/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTest.java
@@ -11,9 +11,12 @@ import com.dynatrace.diagnostics.global.PluginPropertyInstanceConfig;
 import com.dynatrace.diagnostics.global.PluginPropertyTypeConfig;
 import com.dynatrace.diagnostics.global.PluginTypeConfig;
 import com.dynatrace.diagnostics.pdk.MonitorMeasure;
+import com.dynatrace.diagnostics.pdk.PluginEnvironment;
+import com.dynatrace.diagnostics.sdk.HostImpl;
 import com.dynatrace.diagnostics.sdk.MonitorEnvironment30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasure30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasureKey;
+import com.dynatrace.diagnostics.sdk.types.LongType;
 import com.dynatrace.diagnostics.sdk.types.StringType;
 import org.dstadler.commons.testing.MemoryLeakVerifier;
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -50,7 +53,9 @@ public class ExecuteElasticsearchMonitorTest extends ESIntegTestCase {
 	private static final Logger log = Logger.getLogger(ExecuteElasticsearchMonitorTest.class.getName());
 
 	// which URL do we use in test
-	private static final String URL = "http://localhost:19300";
+	private static final String PROTOCOL = "http";
+	private static final Long PORT = 19300L;
+	private static final String URL = "localhost";
 
 	private static MemoryLeakVerifier verifier = new MemoryLeakVerifier();
 
@@ -228,29 +233,44 @@ public class ExecuteElasticsearchMonitorTest extends ESIntegTestCase {
 
 	private MonitorEnvironment30Impl prepareMonitorEnvironment() {
 		PluginInstanceConfig pluginConfig = new PluginInstanceConfig();
+
 		pluginConfig.setKey("elasticsearch");
 
 		{
-			PluginPropertyInstanceConfig environment = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_URL);
-			environment.setSourceTypeId(StringType.TYPE_ID);
-			environment.setValue(URL);
-			pluginConfig.addPluginPropertyConfig(environment);
+			PluginPropertyInstanceConfig propertyProtocol = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL);
+			propertyProtocol.setSourceTypeId(StringType.TYPE_ID);
+			propertyProtocol.setValue(PROTOCOL);
+			pluginConfig.addPluginPropertyConfig(propertyProtocol);
+
+			PluginPropertyInstanceConfig propertyPort = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_PORT);
+			propertyPort.setSourceTypeId(LongType.TYPE_ID);
+			propertyPort.setValue(PORT.toString());
+			pluginConfig.addPluginPropertyConfig(propertyPort);
+
 		}
 
 		PluginTypeConfig pluginTypeConfig = new PluginTypeConfig();
 		pluginTypeConfig.setKey("elasticsearch");
 
 		{
-			PluginPropertyTypeConfig environmentType = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_URL, new StringType("some",
+			PluginPropertyTypeConfig propertyProtocol = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL, new StringType("some",
 					""));
-			environmentType.setSourceTypeId(StringType.TYPE_ID);
-			environmentType.setType(StringType.TYPE_ID);
-			environmentType.setValue(URL);
-			pluginTypeConfig.addPluginPropertyConfig(environmentType);
+			propertyProtocol.setSourceTypeId(StringType.TYPE_ID);
+			propertyProtocol.setType(StringType.TYPE_ID);
+			propertyProtocol.setValue(PROTOCOL);
+			pluginTypeConfig.addPluginPropertyConfig(propertyProtocol);
+
+			PluginPropertyTypeConfig propertyPort = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_PORT, new LongType(0L,
+					9200L));
+			propertyPort.setSourceTypeId(LongType.TYPE_ID);
+			propertyPort.setType(LongType.TYPE_ID);
+			propertyPort.setValue(PORT.toString());
+			pluginTypeConfig.addPluginPropertyConfig(propertyPort);
 		}
 
 		// register all measure groups to have them available during the test
-		MonitorEnvironment30Impl env = new MonitorEnvironment30Impl(null, pluginConfig, pluginTypeConfig, false, null);
+
+		MonitorEnvironment30Impl env = new MonitorEnvironment30Impl(new HostImpl(URL), pluginConfig, pluginTypeConfig, false, null);
 		{
 			for(String measure : ElasticsearchMonitor.ALL_MEASURES) {
 				createMeasure(env, ElasticsearchMonitor.METRIC_GROUP_ELASTICSEARCH, measure);

--- a/testsrcES2/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTest.java
+++ b/testsrcES2/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTest.java
@@ -16,6 +16,7 @@ import com.dynatrace.diagnostics.sdk.HostImpl;
 import com.dynatrace.diagnostics.sdk.MonitorEnvironment30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasure30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasureKey;
+import com.dynatrace.diagnostics.sdk.types.BooleanType;
 import com.dynatrace.diagnostics.sdk.types.LongType;
 import com.dynatrace.diagnostics.sdk.types.StringType;
 import org.dstadler.commons.testing.MemoryLeakVerifier;
@@ -247,6 +248,11 @@ public class ExecuteElasticsearchMonitorTest extends ESIntegTestCase {
 			propertyPort.setValue(PORT.toString());
 			pluginConfig.addPluginPropertyConfig(propertyPort);
 
+			PluginPropertyInstanceConfig useFullConfiguration = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION);
+			useFullConfiguration.setSourceTypeId(BooleanType.TYPE_ID);
+			useFullConfiguration.setValue(Boolean.FALSE.toString());
+			pluginConfig.addPluginPropertyConfig(useFullConfiguration);
+
 		}
 
 		PluginTypeConfig pluginTypeConfig = new PluginTypeConfig();
@@ -266,6 +272,11 @@ public class ExecuteElasticsearchMonitorTest extends ESIntegTestCase {
 			propertyPort.setType(LongType.TYPE_ID);
 			propertyPort.setValue(PORT.toString());
 			pluginTypeConfig.addPluginPropertyConfig(propertyPort);
+
+			PluginPropertyTypeConfig useFullConfiguration = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION,new BooleanType(Boolean.FALSE,Boolean.FALSE));
+			useFullConfiguration.setSourceTypeId(BooleanType.TYPE_ID);
+			useFullConfiguration.setValue(Boolean.FALSE.toString());
+			pluginTypeConfig.addPluginPropertyConfig(useFullConfiguration);
 		}
 
 		// register all measure groups to have them available during the test

--- a/testsrcES5/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTest.java
+++ b/testsrcES5/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTest.java
@@ -12,9 +12,11 @@ import com.dynatrace.diagnostics.global.PluginPropertyInstanceConfig;
 import com.dynatrace.diagnostics.global.PluginPropertyTypeConfig;
 import com.dynatrace.diagnostics.global.PluginTypeConfig;
 import com.dynatrace.diagnostics.pdk.MonitorMeasure;
+import com.dynatrace.diagnostics.sdk.HostImpl;
 import com.dynatrace.diagnostics.sdk.MonitorEnvironment30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasure30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasureKey;
+import com.dynatrace.diagnostics.sdk.types.LongType;
 import com.dynatrace.diagnostics.sdk.types.StringType;
 import org.dstadler.commons.testing.MemoryLeakVerifier;
 import org.elasticsearch.ESNetty3IntegTestCase;
@@ -57,7 +59,9 @@ public class ExecuteElasticsearchMonitorTest extends ESNetty3IntegTestCase {
 	private static final Logger log = Logger.getLogger(ExecuteElasticsearchMonitorTest.class.getName());
 
 	// which URL do we use in test
-	private static final String URL = "http://localhost:19300";
+	private static final Long PORT = 19300L;
+	private static final String PROTOCOL = "http";
+	private static final String URL = "localhost";
 
 	private static MemoryLeakVerifier verifier = new MemoryLeakVerifier();
 
@@ -235,34 +239,50 @@ public class ExecuteElasticsearchMonitorTest extends ESNetty3IntegTestCase {
 
 	private MonitorEnvironment30Impl prepareMonitorEnvironment() {
 		PluginInstanceConfig pluginConfig = new PluginInstanceConfig();
+
 		pluginConfig.setKey("elasticsearch");
 
 		{
-			PluginPropertyInstanceConfig environment = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_URL);
-			environment.setSourceTypeId(StringType.TYPE_ID);
-			environment.setValue(URL);
-			pluginConfig.addPluginPropertyConfig(environment);
+			PluginPropertyInstanceConfig propertyProtocol = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL);
+			propertyProtocol.setSourceTypeId(StringType.TYPE_ID);
+			propertyProtocol.setValue(PROTOCOL);
+			pluginConfig.addPluginPropertyConfig(propertyProtocol);
+
+			PluginPropertyInstanceConfig propertyPort = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_PORT);
+			propertyPort.setSourceTypeId(LongType.TYPE_ID);
+			propertyPort.setValue(PORT.toString());
+			pluginConfig.addPluginPropertyConfig(propertyPort);
+
 		}
 
 		PluginTypeConfig pluginTypeConfig = new PluginTypeConfig();
 		pluginTypeConfig.setKey("elasticsearch");
 
 		{
-			PluginPropertyTypeConfig environmentType = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_URL, new StringType("some",
+			PluginPropertyTypeConfig propertyProtocol = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_PROTOCOL, new StringType("some",
 					""));
-			environmentType.setSourceTypeId(StringType.TYPE_ID);
-			environmentType.setType(StringType.TYPE_ID);
-			environmentType.setValue(URL);
-			pluginTypeConfig.addPluginPropertyConfig(environmentType);
+			propertyProtocol.setSourceTypeId(StringType.TYPE_ID);
+			propertyProtocol.setType(StringType.TYPE_ID);
+			propertyProtocol.setValue(PROTOCOL);
+			pluginTypeConfig.addPluginPropertyConfig(propertyProtocol);
+
+			PluginPropertyTypeConfig propertyPort = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_PORT, new LongType(0L,
+					9200L));
+			propertyPort.setSourceTypeId(LongType.TYPE_ID);
+			propertyPort.setType(LongType.TYPE_ID);
+			propertyPort.setValue(PORT.toString());
+			pluginTypeConfig.addPluginPropertyConfig(propertyPort);
 		}
 
 		// register all measure groups to have them available during the test
-		MonitorEnvironment30Impl env = new MonitorEnvironment30Impl(null, pluginConfig, pluginTypeConfig, false, null);
+
+		MonitorEnvironment30Impl env = new MonitorEnvironment30Impl(new HostImpl(URL), pluginConfig, pluginTypeConfig, false, null);
 		{
 			for(String measure : ElasticsearchMonitor.ALL_MEASURES) {
 				createMeasure(env, ElasticsearchMonitor.METRIC_GROUP_ELASTICSEARCH, measure);
 			}
 		}
+
 		return env;
 	}
 

--- a/testsrcES5/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTest.java
+++ b/testsrcES5/com/dynatrace/diagnostics/plugins/elasticsearch/ExecuteElasticsearchMonitorTest.java
@@ -16,6 +16,7 @@ import com.dynatrace.diagnostics.sdk.HostImpl;
 import com.dynatrace.diagnostics.sdk.MonitorEnvironment30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasure30Impl;
 import com.dynatrace.diagnostics.sdk.MonitorMeasureKey;
+import com.dynatrace.diagnostics.sdk.types.BooleanType;
 import com.dynatrace.diagnostics.sdk.types.LongType;
 import com.dynatrace.diagnostics.sdk.types.StringType;
 import org.dstadler.commons.testing.MemoryLeakVerifier;
@@ -253,6 +254,12 @@ public class ExecuteElasticsearchMonitorTest extends ESNetty3IntegTestCase {
 			propertyPort.setValue(PORT.toString());
 			pluginConfig.addPluginPropertyConfig(propertyPort);
 
+			PluginPropertyInstanceConfig useFullConfiguration = new PluginPropertyInstanceConfig(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION);
+			useFullConfiguration.setSourceTypeId(BooleanType.TYPE_ID);
+			useFullConfiguration.setValue(Boolean.FALSE.toString());
+			pluginConfig.addPluginPropertyConfig(useFullConfiguration);
+
+
 		}
 
 		PluginTypeConfig pluginTypeConfig = new PluginTypeConfig();
@@ -272,6 +279,11 @@ public class ExecuteElasticsearchMonitorTest extends ESNetty3IntegTestCase {
 			propertyPort.setType(LongType.TYPE_ID);
 			propertyPort.setValue(PORT.toString());
 			pluginTypeConfig.addPluginPropertyConfig(propertyPort);
+
+			PluginPropertyTypeConfig useFullConfiguration = new PluginPropertyTypeConfig(ElasticsearchMonitor.ENV_CONFIG_USE_FULL_URL_CONFIGURATION,new BooleanType(Boolean.FALSE,Boolean.FALSE));
+			useFullConfiguration.setSourceTypeId(BooleanType.TYPE_ID);
+			useFullConfiguration.setValue(Boolean.FALSE.toString());
+			pluginTypeConfig.addPluginPropertyConfig(useFullConfiguration);
 		}
 
 		// register all measure groups to have them available during the test


### PR DESCRIPTION

<img width="707" alt="usage_example" src="https://cloud.githubusercontent.com/assets/8741629/22508146/f5cf4b4a-e888-11e6-9554-51dddcad5542.png">
Hello,

I actually tried this plugin and we are now using it.

We are actually working on a few hosts. We are using labels or group hosts. In the project, you used a custom variable. 
I think it's best to use :
env.getHost().getAddress()

Here the java doc description :

getHost
PluginEnvironment.Host getHost()
Returns the host configured for the Plugin. If multiple hosts are configured the Plugins execute method will be called repeatedly for each host. If the Plugin does not support hosts, this method will return null.
Returns:the configured host, or null if hosts are not supported
I made some quick test on my side and everything seems to be working well.

Please fill free to ask any change if anything seems buggy.

Thank you for your time.

Regards,

Sylvain Lebon